### PR TITLE
Add --no-additional-properties option #154

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ To avoid this too strict Schema, you can use `--no-length` option.
 $ ./schema-guru-0.6.2 schema --no-length /path/to/few-instances
 ```
 
+By default Schema Guru sets `"additionalProperties" : true`. To set `"additionalProperties" : false` you can use `--no-additional-properties` option.
+
+```bash
+$ ./schema-guru-0.6.2 schema --no-additional-properties
+```
+
 #### DDL derivation
 
 Like for Schema derivation, for DDL input may be also single file with JSON Schema or directory containing JSON Schemas.

--- a/src/main/scala/com.snowplowanalytics/schemaguru/cli/CommandContainer.scala
+++ b/src/main/scala/com.snowplowanalytics/schemaguru/cli/CommandContainer.scala
@@ -97,6 +97,12 @@ case class CommandContainer(command: Option[SchemaGuruCommand] = None) {
       case other => other
     }
 
+  def setNoAdditionalProperties(flag: Boolean): Option[SchemaGuruCommand] =
+    command match {
+      case Some(schema: SchemaCommand) => Some(schema.copy(noAdditionalProperties = flag))
+      case other => other
+    }
+
   // ddl
   def setSchema(name: String): Option[DdlCommand] =
     command match {

--- a/src/main/scala/com.snowplowanalytics/schemaguru/cli/Parser.scala
+++ b/src/main/scala/com.snowplowanalytics/schemaguru/cli/Parser.scala
@@ -66,6 +66,10 @@ object Parser {
           c.copy(command = c.setNdjson(true)) }
           text "Expect newline-delimited JSON",
 
+        opt[Unit]("no-additional-properties")    action { (_, c) =>
+          c.copy(command = c.setNoAdditionalProperties(true)) }
+          text "Switch additionalProperties to false\n\tAdditional properties denied",
+
         opt[String]("vendor")
           action { (x, c) => c.copy(command = c.setVendor(x)) }
           valueName "<title>"

--- a/src/main/scala/com.snowplowanalytics/schemaguru/cli/SchemaCommand.scala
+++ b/src/main/scala/com.snowplowanalytics/schemaguru/cli/SchemaCommand.scala
@@ -46,7 +46,8 @@ case class SchemaCommand private[schemaguru](
   schemaver: Option[SchemaVer] = None,
   schemaBy: Option[String] = None,
   noLength: Boolean = false,
-  ndjson: Boolean = false) extends SchemaGuruCommand {
+  ndjson: Boolean = false,
+  noAdditionalProperties: Boolean = false) extends SchemaGuruCommand {
 
   /**
    * Preference representing Schema-segmentation
@@ -142,7 +143,7 @@ case class SchemaCommand private[schemaguru](
    *         during process of derivation
    */
   private def produce(name: Option[String], jsons: List[JValue]): SchemaGuruResult = {
-    val context = SchemaContext(enumCardinality, successfulEnumSets, Some(jsons.length), !noLength)
+    val context = SchemaContext(enumCardinality, successfulEnumSets, Some(jsons.length), !noLength, noAdditionalProperties)
     val convertResult = SchemaGuru.convertsJsonsToSchema(jsons, context)
     SchemaGuru.mergeAndTransform(convertResult, context)
       .describe(vendor, name, schemaver)

--- a/src/main/scala/com.snowplowanalytics/schemaguru/schema/Helpers.scala
+++ b/src/main/scala/com.snowplowanalytics/schemaguru/schema/Helpers.scala
@@ -39,8 +39,9 @@ object Helpers extends Serializable {
    * @param enumSets list of all predefined enums
    * @param quantity quantity of valid JSON instances to process
    * @param deriveLength flag to disable minLength/maxLength derivation
+   * @param noAdditionalProperties flag to disable additional properties (if true - additionalProperties = 'false')
    */
-  case class SchemaContext(enumCardinality: Int, enumSets: List[JArray] = Nil, quantity: Option[Int] = None, deriveLength: Boolean = true) {
+  case class SchemaContext(enumCardinality: Int, enumSets: List[JArray] = Nil, quantity: Option[Int] = None, deriveLength: Boolean = true, noAdditionalProperties: Boolean = false) {
     private lazy val sets: List[(Set[JValue], Int)] = enumSets.map { e =>
       val set = e.arr.toSet
       val size = set.size

--- a/src/main/scala/com.snowplowanalytics/schemaguru/schema/types/ObjectSchema.scala
+++ b/src/main/scala/com.snowplowanalytics/schemaguru/schema/types/ObjectSchema.scala
@@ -34,7 +34,7 @@ final case class ObjectSchema(properties: Map[String, JsonSchema])(implicit val 
 
   def toJson = ("type" -> "object") ~ ("properties" -> properties.map {
     case (key, value) => key -> value.toJson
-  }) ~ ("additionalProperties" -> false)
+  }) ~ ("additionalProperties" -> !schemaContext.noAdditionalProperties)
 
   def mergeSameType(implicit schemaContext: SchemaContext) = {
 


### PR DESCRIPTION
This change implements --no-additional-properties option.
By default Schema Guru sets "additionalProperties" : true. 
To set "additionalProperties" : false you can use --no-additional-properties option.